### PR TITLE
Fix app icon being too big

### DIFF
--- a/themes-cores/nocturnal.css
+++ b/themes-cores/nocturnal.css
@@ -512,8 +512,8 @@
 #app-mount .tutorialContainer__1f388 .childWrapper__6e9f8:has(svg)::after {
     position: absolute;
     content: "";
-    width: 36px;
-    height: 36px;
+    width: 30px;
+    height: 30px;
     top: 6px;
     left: 6px;
     background-image: linear-gradient(-45deg, var(--gradientColor01), var(--gradientColor02));


### PR DESCRIPTION
Currently, the app icon looks like this, which is too big
![Capture d’écran (841)](https://github.com/user-attachments/assets/b75fdc5d-466f-4f36-aae7-a941e54a3acc)
This fix makes it looking like this 
![Capture d’écran (842)](https://github.com/user-attachments/assets/964fc9f0-6f7c-4cdd-b4dd-54f6dba63867)
